### PR TITLE
Change closed join behavior, and fixes joining bug

### DIFF
--- a/talli-app/client/src/components/OrganizerView/Dialogs/EditVoting.js
+++ b/talli-app/client/src/components/OrganizerView/Dialogs/EditVoting.js
@@ -24,6 +24,7 @@ export default class EditVoting extends React.Component {
             '/event/' + this.props.event.id +
             '/eventData/');
         itemsRef.child('startVote').set(new Date().toISOString());
+        itemsRef.child('endVote').set('none');
         this.handleClose();
     }
 

--- a/talli-app/client/src/components/VoterView/Dialogs/RejoinClosed.js
+++ b/talli-app/client/src/components/VoterView/Dialogs/RejoinClosed.js
@@ -27,7 +27,7 @@ export default class RejoinClosed extends React.Component {
                     </DialogTitle>
                     <DialogContent>
                         The event you were participating in, <b>{this.props.eventName}</b>, has closed. 
-                        Your vote have been automatically submitted. 
+                        Your vote has been automatically submitted. 
                     </DialogContent>
                     <DialogActions>
                         <Button onClick={this.handleClose} color="primary">Go Back</Button>

--- a/talli-app/client/src/components/VoterView/Dialogs/RejoinClosed.js
+++ b/talli-app/client/src/components/VoterView/Dialogs/RejoinClosed.js
@@ -26,8 +26,8 @@ export default class RejoinClosed extends React.Component {
                         Alerts
                     </DialogTitle>
                     <DialogContent>
-                        The event you were participating in, <b>{this.props.eventName}</b>, has closed. 
-                        Your vote has been automatically submitted. 
+                        The event you were participating in, <b>{this.props.eventName}</b>, has closed.
+                        Your vote has been automatically submitted.
                     </DialogContent>
                     <DialogActions>
                         <Button onClick={this.handleClose} color="primary">Go Back</Button>

--- a/talli-app/client/src/components/VoterView/JoinEvent.js
+++ b/talli-app/client/src/components/VoterView/JoinEvent.js
@@ -153,7 +153,7 @@ export default class JoinEvent extends React.Component {
         firebase.database().ref(`attendees/${cookie}/currentEvent`).once('value').then(snapshot => {
             currentEventId = snapshot.val();
             console.log(currentEventId);
-            });
+        });
         if (this.state.idFieldValue === this.state.eventID && this.state.idFieldValue.length > 2 && this.state.eventID === currentEventId) {
             console.log("rejoined");
             this.handleRejoinEvent();

--- a/talli-app/client/src/components/VoterView/JoinEvent.js
+++ b/talli-app/client/src/components/VoterView/JoinEvent.js
@@ -61,7 +61,7 @@ export default class JoinEvent extends React.Component {
                                     if (votingState === 'closed') {
                                         this.rejoinClosedChild.current.handleOpen();
                                         firebase.database().ref(`attendees/${cookie}/currentEvent`).set('');
-                                        firebase.database().ref(`attendees/${cookie}/pastEvents`).set(`${event['eventData'].id}`);
+                                        firebase.database().ref(`attendees/${cookie}/pastEvents`).push(`${event['eventData'].id}`);
                                         return;
                                     }
                                     this.rejoinChild.current.handleOpen();

--- a/talli-app/client/src/components/VoterView/JoinEvent.js
+++ b/talli-app/client/src/components/VoterView/JoinEvent.js
@@ -61,7 +61,6 @@ export default class JoinEvent extends React.Component {
                                     if (votingState === 'closed') {
                                         this.rejoinClosedChild.current.handleOpen();
                                         firebase.database().ref(`attendees/${cookie}/currentEvent`).set('');
-                                        firebase.database().ref(`attendees/${cookie}/pastEvents`).push(`${event['eventData'].id}`);
                                         return;
                                     }
                                     this.rejoinChild.current.handleOpen();


### PR DESCRIPTION
Joining a closed event no longer checks for the event start/end date just the vote time.

A bug that allowed a user to rejoin a closed event by trying twice has been resolved.