### PR TITLE
Updated QR Read/Write

### DIFF
--- a/talli-app/README.md
+++ b/talli-app/README.md
@@ -27,7 +27,6 @@ The configuration for Talli is stored in two files.
 | field     | type | description   |
 | --------- |:----:|:-------------|
 | `hostURL` | string | The host url (ie `tallivote.com`) that the application will be running on.  Make sure that if you are running the application on a subdomain or subdirectory you put the root of the application in this field (ie `subdomain.tallivote.com` or `tallivote.com/subdirectory`) |
-| `entryQRPrefix` | string | The prefix used to generate entry QR codes (ie `entry//` will result in QR codes of the form `entry//1234`) |
 | `sslEnabled` | bool | Tells the application if you're running securely (via ssl/https).  Make sure this matches your server configuration, and note that it must be anabled for QR scanning to function. |
 | `serverPort` | string | The port that the node.js backend of the application is running on |
 | `devMode` | bool | Enables dev mode if true, which tells the client to communicate with the server on localhost instead of the hostURL |

--- a/talli-app/client/src/components/MainPage.js
+++ b/talli-app/client/src/components/MainPage.js
@@ -42,7 +42,7 @@ export default class MainPage extends Component {
         this.props.onSuccess(response);
         this.ChangeView('/organizer');
     }
-    
+
     onFailure() {
         console.log('Login failed');
     }
@@ -76,7 +76,8 @@ export default class MainPage extends Component {
                                     <Button variant="contained" color="primary" className="buttons" onClick={renderProps.onClick}>Login as an Event Organizer</Button>
                                 )}
                                 onSuccess={this.onSuccess.bind(this)}
-                                onFailure={this.onFailure.bind(this)} />
+                                onFailure={this.onFailure.bind(this)}
+                            />
                             {/* Nick messing around with other login possibilities */}
                             {/* <Button variant="contained" color="primary" className="buttons" onClick={() => this.sendLoginRequest()}>Organizer Login</Button> */}
                         </ListItem>

--- a/talli-app/client/src/components/NavBar.js
+++ b/talli-app/client/src/components/NavBar.js
@@ -33,7 +33,7 @@ export default class NavBar extends Component {
     }
 
     toggleDrawer = () => this.setState({ open: !this.state.open });
-    
+
     closeDrawer = () => this.setState({ open: false });
 
     onSuccess = (response) => {
@@ -84,7 +84,7 @@ export default class NavBar extends Component {
 
         return (
             <div className="root">
-                <AppBar position="static" >
+                <AppBar position="static">
                     <Toolbar>
                         <IconButton className="menuButton" color="inherit" aria-label="Menu" onClick={this.toggleDrawer}>
                             <MenuIcon />

--- a/talli-app/client/src/components/OrganizerView/AddEntryOrg.js
+++ b/talli-app/client/src/components/OrganizerView/AddEntryOrg.js
@@ -134,7 +134,7 @@ export default class AddEntryOrg extends Component {
                 </Button>
                 <br /><br />
                 <Typography variant="subtitle1" align="center">{this.state.alert}</Typography>
-                <Button variant="text" className="buttons" onClick={this.openInfo} >Click here for import requirements.</Button>
+                <Button variant="text" className="buttons" onClick={this.openInfo}>Click here for import requirements.</Button>
                 <Divider variant="middle" />
                 <form className="entryForm" onSubmit={() => this.submitEntries()}>
                     {

--- a/talli-app/client/src/components/OrganizerView/Dialogs/ExportOrgData.js
+++ b/talli-app/client/src/components/OrganizerView/Dialogs/ExportOrgData.js
@@ -72,7 +72,7 @@ export default class ExportOrgData extends Component {
                     if (offset === 0) { doc.addPage(); }
                     title = `Entry ID: ${entry.id}`;
                     entryTitle = doc.splitTextToSize(entry.title, 180);
-                    qrCode = qr.imageSync(config.Global.entryQRPrefix + String(entry.id));
+                    qrCode = qr.imageSync(`${config.Global.hostURL}/vote/${this.props.event.id}/${entry.id}`);
                     doc.addImage(qrCode, 'PNG', 58, 20 + offset, 100, 100); // QR code
                     doc.text(entryTitle, 108, 20 + offset, 'center'); // entry title
                     doc.text(title, 108, 118 + offset, 'center'); // entry id

--- a/talli-app/client/src/components/OrganizerView/Dialogs/ShowError.js
+++ b/talli-app/client/src/components/OrganizerView/Dialogs/ShowError.js
@@ -1,8 +1,6 @@
 import React, { Component } from 'react';
 import { Slide, Dialog, DialogTitle, DialogContent, DialogActions, Button } from '@material-ui/core';
 
-
-
 function Transition(props) {
     return <Slide direction="up" {...props} />;
 }
@@ -20,7 +18,7 @@ export default class ShowError extends Component {
     handleOpen = (message) => {
         this.setState({
             open: true,
-            message: message,
+            message,
         });
     }
 

--- a/talli-app/client/src/components/OrganizerView/EventList.js
+++ b/talli-app/client/src/components/OrganizerView/EventList.js
@@ -18,7 +18,6 @@ export default class EventList extends Component {
     }
 
     componentDidMount() {
-        console.log('mounted')
         const googleId = this.props.user.googleId;
         const query = firebase.database().ref(`organizer/${googleId}/event`);
         const allEvents = [];

--- a/talli-app/client/src/components/OrganizerView/NewEventForm.js
+++ b/talli-app/client/src/components/OrganizerView/NewEventForm.js
@@ -173,18 +173,18 @@ export default class NewEventForm extends Component {
                     </MuiPickersUtilsProvider>
                     <br /> <br />
                     <FormControlLabel
-                        control={
+                        control={(
                             <Switch
                                 checked={this.state.eventData.automate}
                                 onChange={() => this.toggleAutomation()}
                                 value={this.state.eventData.automate}
                                 color="primary"
                             />
-                        }
+                        )}
                         label="Automate Voting Time Period?"
                         labelPlacement="start"
                     />
-                    {this.state.eventData.automate &&
+                    {this.state.eventData.automate && (
                         <div>
                             <MuiPickersUtilsProvider utils={DateFnsUtils}>
                                 <Typography className="votePeriodText">Start Voting:</Typography>
@@ -217,7 +217,7 @@ export default class NewEventForm extends Component {
                                 />
                             </MuiPickersUtilsProvider>
                         </div>
-                    }
+                    )}
                     <br /> <br />
                     <Button
                         variant="contained"

--- a/talli-app/client/src/components/OrganizerView/ViewEvent.js
+++ b/talli-app/client/src/components/OrganizerView/ViewEvent.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { Typography, Button, TextField, Tooltip } from '@material-ui/core';
 import openSocket from 'socket.io-client';
+import CheckCircle from '@material-ui/icons/CheckCircle';
 import firebase from '../../firebase';
 import ExportOrgData from './Dialogs/ExportOrgData';
 import EditEntries from './Dialogs/EditEntries';
@@ -11,7 +12,6 @@ import EditWeights from './Dialogs/EditWeights';
 import AddBallot from './Dialogs/AddBallot';
 import ShowError from './Dialogs/ShowError';
 import ConfirmFinalize from './Dialogs/ConfirmFinalize';
-import CheckCircle from '@material-ui/icons/CheckCircle';
 import '../component_style/ViewEvent.css';
 
 const config = require('../../config.json');
@@ -238,8 +238,8 @@ export default class ViewEvent extends Component {
             if (event.attendees) {
                 const totalBallots = Object.keys(event.attendees).length;
                 let totalSubmitted = 0;
-                let topVotes = {};
-                let sortVotes = [];
+                const topVotes = {};
+                const sortVotes = [];
                 for (let user in event.attendees) {
                     if (event.attendees[user].submitted) {
                         totalSubmitted += 1;
@@ -266,9 +266,7 @@ export default class ViewEvent extends Component {
                 for (let ballot in topVotes) {
                     sortVotes.push([ballot, topVotes[ballot]]);
                 }
-                sortVotes.sort((a,b) => {
-                    return b[1] - a[1];
-                });
+                sortVotes.sort((a, b) => b[1] - a[1]);
                 const topThree = {
                     first: this.state.event.entries[sortVotes[0][0]] ? this.state.event.entries[sortVotes[0][0]].title : '',
                     second: this.state.event.entries[sortVotes[1][0]] ? this.state.event.entries[sortVotes[1][0]].title : '',
@@ -396,8 +394,8 @@ export default class ViewEvent extends Component {
                                             </div>
                                         </div>
                                     </div>
-                             
-                               
+
+
                                     <div className="statistics">
                                         <Typography id="itemTitle" variant="h5">Voting Statistics</Typography>
                                         <div>Total Ballots: {this.state.totalBallots}</div>
@@ -411,15 +409,15 @@ export default class ViewEvent extends Component {
                                             </div>
                                         </div>
                                         <div className="refreshButton">
-                                        <Button variant="contained" size="small" color="default" onClick={this.refreshStats}>
-                                            Refresh Statistics
+                                            <Button variant="contained" size="small" color="default" onClick={this.refreshStats}>
+                                                Refresh Statistics
                                         </Button>
                                         </div>
                                     </div>
                                 </div>
                                 <div className="bottomMenu">
                                     <div className="resultsOption">
-                                        <Tooltip 
+                                        <Tooltip
                                             title="Updates linked google sheet with current list of entries. It's best to do this before the event starts!"
                                             placement="bottom"
                                         >
@@ -434,9 +432,9 @@ export default class ViewEvent extends Component {
                                         >
                                             <Button className="listButtons" onClick={this.handleWeights}>Apply Custom Weights</Button>
                                         </Tooltip>
-                                    </div>  
+                                    </div>
                                     <div className="resultsOption">
-                                        <Tooltip 
+                                        <Tooltip
                                             title="Manually add a ballot to the results."
                                             placement="bottom"
                                         >
@@ -454,7 +452,7 @@ export default class ViewEvent extends Component {
                                             </Button>
                                         </Tooltip>
                                     </div>
-                                    
+
                                 </div>
                             </div>
                         </div>

--- a/talli-app/client/src/components/VoterView/AddEntryVote.js
+++ b/talli-app/client/src/components/VoterView/AddEntryVote.js
@@ -58,8 +58,12 @@ export default class AddEntryVote extends Component {
     }
 
     handleScan(data) {
-        if (data && data.toLowerCase().includes(config.Global.entryQRPrefix)) {
-            const id = data.substring(data.indexOf(config.Global.entryQRPrefix) + 7).replace(/\W/g, '');
+        if (data
+            && data.toLowerCase().includes((`${config.Global.hostURL}/vote/`).toLowerCase())
+            && data.indexOf('/', data.indexOf('/vote/') + 6) !== -1
+        ) {
+            const entrySlash = data.indexOf('/', data.indexOf('/vote/') + 6);
+            const id = data.substring(entrySlash).replace(/\W/g, '');
             this.setState({ entryID: id });
             this.requestConfirm();
         }

--- a/talli-app/client/src/config.json
+++ b/talli-app/client/src/config.json
@@ -1,7 +1,6 @@
 {
     "Global": {
         "hostURL": "tallivote.com",
-        "entryQRPrefix": "entry//",
         "sslEnabled": true,
         "serverPort": "5000",
         "devMode": true

--- a/talli-app/client/src/routing/routing.js
+++ b/talli-app/client/src/routing/routing.js
@@ -52,7 +52,7 @@ const RoutedApp = createReactClass({
     },
 
     joinWithEntry(event, entry) {
-        return <Voter scanID={event} scanEntry={entry}/>;
+        return <Voter scanID={event} scanEntry={entry} />;
     },
 
     organizer() {

--- a/talli-app/client/src/routing/routing.js
+++ b/talli-app/client/src/routing/routing.js
@@ -25,6 +25,7 @@ const RoutedApp = createReactClass({
         '/': 'home',
         '/vote': 'vote',
         '/vote/:text': 'voteWithID',
+        '/vote/:event/:entry': 'joinWithEntry',
         '/organizer': 'organizer',
         '/cookies': 'cookies'
     },
@@ -48,6 +49,10 @@ const RoutedApp = createReactClass({
 
     voteWithID(text) {
         return <Voter scanID={text} />;
+    },
+
+    joinWithEntry(event, entry) {
+        return <Voter scanID={event} scanEntry={entry}/>;
     },
 
     organizer() {

--- a/talli-app/server/server.js
+++ b/talli-app/server/server.js
@@ -73,7 +73,7 @@ io.on('connection', function (socket) {
                         const sheet = info.worksheets[0];
                         sheet.setTitle('all votes');
                         sheet.setHeaderRow(['submission_num', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten']);
-                        
+
                         doc.addWorksheet({
                             title: 'weighted rankings'
                         }, (err3, sheet2) => {


### PR DESCRIPTION
Updated entry QRs to be of the form hostUrl/vote/eventId/entryId (eg. tallivote.com/vote/1234/5678)

This allows the following:
- Attendees can scan any event/entry qr to join the event (not just the event qr)
- If an entry qr is scanned first, that entry is automatically added when the event is joined
- Posters only need to have one QR code attached to them (no need for the event qr besides at locations such as conference entrance)

Also made some stylefixes because codefactor was yelling at me, so the actual files to look at for this pr are:
- ExportOrgData.js
- AddEntryVote.js
- JoinEvent.js
- routing.js